### PR TITLE
Resources: Team manifest create/update/delete support.

### DIFF
--- a/example/local-install/main.tf
+++ b/example/local-install/main.tf
@@ -142,3 +142,18 @@ provider "span" {
 #    }
 #  }
 #}
+
+# ===============
+# Resources:
+# ===============
+
+# span_team_manifest resource allows to create and update
+# enumerated properties for a team's manifest
+
+# resource "span_team_manifest" "core_team_manifest" {
+#   team_id = "6d427a01-9c0a-4ec5-bdd0-a0c364c42baf" # required
+#   reference = "@span/core-team" # required
+#   vendors_input = jsonencode({"pagerduty": {"schedule": "PI7DH85"}})
+#}
+
+# The output is equivalent to the data source schema.

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -8,3 +8,8 @@ type FindPeopleRequest struct {
 type FindTeamsRequest struct {
 	Name string
 }
+
+type SetTeamManifestRequest struct {
+	Reference string         `json:"externalReference"`
+	Vendors   map[string]any `json:"vendors"`
+}

--- a/span/data_source_team_manifest.go
+++ b/span/data_source_team_manifest.go
@@ -23,7 +23,7 @@ type TeamManifestDataSource struct {
 	apiClient api.SpanAPIClient
 }
 
-type TeamManifestResourceData struct {
+type teamManifestDataSourceData struct {
 	TeamID    types.String  `tfsdk:"team_id"`
 	TeamName  types.String  `tfsdk:"team_name"`
 	Reference types.String  `tfsdk:"reference"`
@@ -31,8 +31,8 @@ type TeamManifestResourceData struct {
 	Vendors   types.Dynamic `tfsdk:"vendors"`
 }
 
-func newTeamManifestResourceData(_ context.Context, in *api.TeamManifest) (*TeamManifestResourceData, error) {
-	var data TeamManifestResourceData
+func newTeamManifestDataSourceData(_ context.Context, in *api.TeamManifest) (*teamManifestDataSourceData, error) {
+	var data teamManifestDataSourceData
 
 	data.TeamID = types.StringValue(in.TeamID)
 	data.TeamName = types.StringValue(in.TeamName)
@@ -46,16 +46,15 @@ func newTeamManifestResourceData(_ context.Context, in *api.TeamManifest) (*Team
 		return nil, err
 	}
 
-	data.Vendors, err = dynamic.DynamicFromJSON(vendorsInput)
+	data.Vendors, err = dynamic.FromJSON(vendorsInput)
 	if err != nil {
 		return nil, err
 	}
 
 	return &data, nil
-
 }
 
-func (tmr TeamManifestResourceData) Attributes() map[string]schema.Attribute {
+func (tmr teamManifestDataSourceData) Attributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"team_id": schema.StringAttribute{
 			MarkdownDescription: "The team id owner for the manifest resource.",
@@ -87,7 +86,7 @@ func (d *TeamManifestDataSource) Metadata(_ context.Context, req datasource.Meta
 func (d *TeamManifestDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "A data source representation for manifest details stored for a team resource.",
-		Attributes:          TeamManifestResourceData{}.Attributes(),
+		Attributes:          teamManifestDataSourceData{}.Attributes(),
 	}
 }
 
@@ -109,7 +108,7 @@ func (d *TeamManifestDataSource) Configure(_ context.Context, req datasource.Con
 }
 
 func (d *TeamManifestDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data TeamManifestResourceData
+	var data teamManifestDataSourceData
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -134,7 +133,7 @@ func (d *TeamManifestDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	resource, err := newTeamManifestResourceData(ctx, response)
+	resource, err := newTeamManifestDataSourceData(ctx, response)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Could not load manifest", fmt.Sprintf("Schema mapping for manifiest failed with %v", err))

--- a/span/internal/serde/dynamic.go
+++ b/span/internal/serde/dynamic.go
@@ -73,8 +73,8 @@ func mapToJSON(b []byte) (attr.Type, attr.Value, error) {
 	}
 }
 
-// DynamicFromJSON maps serialized json string to TF dynamic type ad-hoc.
-func DynamicFromJSON(b []byte) (types.Dynamic, error) {
+// FromJSON maps serialized json string to TF dynamic type ad-hoc.
+func FromJSON(b []byte) (types.Dynamic, error) {
 	_, v, err := mapToJSON(b)
 	if err != nil {
 		return types.Dynamic{}, err

--- a/span/provider.go
+++ b/span/provider.go
@@ -133,5 +133,7 @@ func (p *spanProvider) DataSources(_ context.Context) []func() datasource.DataSo
 
 // Resources returns a slice of functions to instantiate supported Resource implementations
 func (p *spanProvider) Resources(_ context.Context) []func() resource.Resource {
-	return nil
+	return []func() resource.Resource{
+		NewTeamManifestResource,
+	}
 }


### PR DESCRIPTION
Adds a terraform manifest resource with ability to write enumerated fields. Currently supports CRUD operations w/o import.